### PR TITLE
Include less/Less.php, not less/Cache.php

### DIFF
--- a/htdocs/includes/bootstrap.php
+++ b/htdocs/includes/bootstrap.php
@@ -2,8 +2,12 @@
 if(!class_exists("Mobile_Detect")) {
 	require __DIR__.'/mobileDetect/Mobile_Detect.php';
 }
+// While only the Less_Cache class is needed, the error
+// reporting class must be present first so any errors
+// encountered by the less/Cache.php file can be thrown.
+// so include less/Less.php and not less/Cache.php
 if(!class_exists("Less_Cache")) {
-	require __DIR__.'/less/Cache.php';
+	require __DIR__.'/less/Less.php';
 }
 if(!class_exists("JShrink\Minifier")) {
 	require __DIR__.'/js/Minifier.php';


### PR DESCRIPTION
If the Cache module fails for some reason, it will attempt to
throw a Less_Exception_Parser type of exception.  However, if
only the less/Cache.php file is included, that class will not
have been defined.  (It is defined in "less/Less.php".)

So, include less/Less.php, so the Less_Exception_Parser class
can be defined, so when an error occurs, it can be reported
successfully.