### PR TITLE
generic htaccess

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -5,11 +5,28 @@ SetEnv HTACCESS on
 </Files>
 
 <FilesMatch "\..*$">
-	Deny from all
+	<IfModule !authz_core_module>
+	        #apache 2.2
+	        Order allow,deny
+	        Deny from all
+	</IfModule>
+	<IfModule authz_core_module>
+		#apache 2.4
+		Require all denied
+	</IfModule>
 </FilesMatch>
 
 # Now allow /index.php as well as the various assets
 #
 <FilesMatch "(^$|index\.php|\.(gif|GIF|jpg|jpeg|png|css|js|swf|txt|ico|ttf|svg|eot|woff|woff2|wav|mp3|aac|ogg|webm|less)$)">
-	Allow from all
+	<IfModule authz_core_module>
+		#apache 2.4 added mod_authz_core which changes the layout
+		Require all granted
+	</IfModule>
+	
+	<IfModule !authz_core_module>
+		#apache 2.2 
+		Order allow,deny
+		Allow from all
+	</IfModule>
 </FilesMatch>


### PR DESCRIPTION
made htaccess compatible with apache 2.2 and 24 with or without access_compat_module

This is a pretty harmless change and makes it easier to upgrade or change webserver configuration.

I'm filling out the contributor form.