### PR TITLE
fix 502 bad gateway when behind haproxy

### DIFF
--- a/htdocs/includes/Session.class.php
+++ b/htdocs/includes/Session.class.php
@@ -117,6 +117,7 @@ class Session extends UCP {
 	private function startSession() {
 		if(!headers_sent()) {
 			session_start();
+			if (SID) header('Set-Cookie: '.SID.'; path=/', true);
 		}
 	}
 }


### PR DESCRIPTION
see [here](https://community.freepbx.org/t/haproxy-as-frontend-for-ucp-backend-phpsessid-repeated-41-times-in-response-why/47933/9)