### PR TITLE
Fixed 44. The issue of UCP attempts connection to node server even when it is disabled.

### DIFF
--- a/htdocs/assets/js/ucp.js
+++ b/htdocs/assets/js/ucp.js
@@ -477,8 +477,21 @@ var UCPC = Class.extend({
 				callback(socket);
 			});
 			socket.on("connect_error", function(reason) {
-				UCP.displayGlobalMessage(sprintf(_("Unable to connect to the UCP Node Server.<br>%s"),reason), "red", true);
-				callback(false);
+				$.ajax({
+					url: "ajax.php", data: { module: "ucp", command: "fetchSettings" }, success: function (data) {
+						ucpserver = data.ucpserver;
+						if (!ucpserver.enabled) {
+							clearTimeout(timeout);
+							socket.disconnect();
+							UCP.removeGlobalMessage();
+						} else {
+							UCP.displayGlobalMessage(sprintf(_("Unable to connect to the UCP Node Server.<br>%s"), reason), "red", true);
+						}
+						callback(false);
+					}, error: function (xhr, status, error) {
+						console.error("Error fetching settings:", error);
+					}, dataType: "json", type: "POST"
+				});
 			});
 		}
 	},

--- a/htdocs/includes/Ajax.class.php
+++ b/htdocs/includes/Ajax.class.php
@@ -68,6 +68,14 @@ class Ajax extends UCP {
 				}
 				$this->addHeader('HTTP/1.0','200');
 			break;
+			case 'fetchSettings':
+				try {
+					$ret = ['status' => true , 'ucpserver' => $this->UCP->getServerSettings()];
+				} catch (Exception $e){
+					$ret = ['status' => false, 'message' => 'There is an error fetching server settings: '.$e->getMessage()];
+				}
+				$this->addHeader('Content-Type', 'application/json');
+			break;
 			default:
 				if (!$module || !$command) {
 					$this->triggerFatal(_("Module or Command were null. Check your code."));


### PR DESCRIPTION
**Current Behavior:**


![image](https://github.com/FreePBX/ucp/assets/161284147/0aa14168-ec6b-4d36-b8e8-74ebc02b564f)
> At present, the module operates as follows:
> 
> The **NODEJSENABLED** value applies to the backend server only during UCP module installation. This means that enabling or disabling the node server for UCP requires setting the **NODEJSENABLED** value from the advanced settings page and then performing a module install.
> For the frontend to take action on the updated value of **NODEJSENABLED** , a page reload is necessary.

**Issue Description:**

> The issue arises when the UCP attempts to connect to the UCP node server even when it's disabled, but only under specific conditions. This occurs when the UI is initially loaded with the **NODEJSENABLED** value set to 'yes', and later it's changed to 'no'.

**Expected Behavior:**

> Following the provided steps in the _Current Behavior_ session should prevent the specified error. But normally, users anticipate an immediate effect on the already loaded page when the value in the advanced settings is altered. For a smoother user experience, immediate reflection is preferred, at least for the transition of node js server configuration value from **enabled** to **disabled**

**Solution:**

> To address this, a client-side check has been added to display a warning only if the **NODEJSENABLED** value is enabled in the advanced settings.